### PR TITLE
Fix Runtime Errors and Fix Easter Egg Replaced Behaviours

### DIFF
--- a/timer.gsc
+++ b/timer.gsc
@@ -1206,26 +1206,32 @@ madeup_replaces()
 {
     if(getDvarInt("EE_madeup"))
     {
-        //tranzit
-        replacefunc(getfunction("maps/mp/zm_transit_sq", "maxis_sidequest_b"), ::replace_maxis_sidequest_b);
-        replacefunc(getfunction("maps/mp/zm_transit_sq", "get_how_many_progressed_from"), ::replace_get_how_many_progressed_from);
+        switch ( level.script )
+        {
+            case "zm_transit": //tranzit
+                replacefunc(getfunction("maps/mp/zm_transit_sq", "maxis_sidequest_b"), ::replace_maxis_sidequest_b);
+                replacefunc(getfunction("maps/mp/zm_transit_sq", "get_how_many_progressed_from"), ::replace_get_how_many_progressed_from);
+                break;
 
-        //die rise
-        replacefunc(getfunction("maps/mp/zm_highrise_sq_atd", "sq_atd_elevators"), ::replace_sq_atd_elevators);
-        replacefunc(getfunction("maps/mp/zm_highrise_sq_atd", "sq_atd_drg_puzzle"), ::replace_sq_atd_drg_puzzle);
-        replacefunc(getfunction("maps/mp/zm_highrise_sq_pts", "wait_for_all_springpads_placed"), ::replace_wait_for_all_springpads_placed);
-        replacefunc(getfunction("maps/mp/zm_highrise_sq_pts", "pts_should_player_create_trigs"), ::replace_pts_should_player_create_trigs);
-        replacefunc(getfunction("maps/mp/zm_highrise_sq_pts", "pts_should_springpad_create_trigs"), ::replace_pts_should_springpad_create_trigs);
-        replacefunc(getfunction("maps/mp/zm_highrise_sq_pts", "pts_putdown_trigs_create_for_spot"), ::replace_pts_putdown_trigs_create_for_spot);
-        replacefunc(getfunction("maps/mp/zm_highrise_sq_pts", "place_ball_think"), ::replace_place_ball_think);
+            case "zm_highrise": //die rise
+                replacefunc(getfunction("maps/mp/zm_highrise_sq_atd", "sq_atd_elevators"), ::replace_sq_atd_elevators);
+                replacefunc(getfunction("maps/mp/zm_highrise_sq_atd", "sq_atd_drg_puzzle"), ::replace_sq_atd_drg_puzzle);
+                replacefunc(getfunction("maps/mp/zm_highrise_sq_pts", "wait_for_all_springpads_placed"), ::replace_wait_for_all_springpads_placed);
+                replacefunc(getfunction("maps/mp/zm_highrise_sq_pts", "pts_should_player_create_trigs"), ::replace_pts_should_player_create_trigs);
+                replacefunc(getfunction("maps/mp/zm_highrise_sq_pts", "pts_should_springpad_create_trigs"), ::replace_pts_should_springpad_create_trigs);
+                replacefunc(getfunction("maps/mp/zm_highrise_sq_pts", "pts_putdown_trigs_create_for_spot"), ::replace_pts_putdown_trigs_create_for_spot);
+                replacefunc(getfunction("maps/mp/zm_highrise_sq_pts", "place_ball_think"), ::replace_place_ball_think);
+                break;
 
-        //buried
-        replacefunc(getfunction("maps/mp/zm_buried_sq", "sq_metagame"), ::replace_sq_metagame);
-        replaceFunc(getfunction("maps/mp/zm_buried_sq_ctw", "ctw_max_wisp_enery_watch"), ::replace_ctw_max_wisp_enery_watch );
-        replacefunc(getfunction("maps/mp/zm_buried_sq_tpo", "_are_all_players_in_time_bomb_volume"), ::replace_are_all_players_in_time_bomb_volume);
-        replacefunc(getfunction("maps/mp/zm_buried_sq_ip", "sq_bp_set_current_bulb"), ::replace_sq_bp_set_current_bulb);
-        replacefunc(getfunction("maps/mp/zm_buried_sq_ows", "ows_target_delete_timer"), ::replace_ows_target_delete_timer);
-        replacefunc(getfunction("maps/mp/zm_buried_sq_ows", "ows_targets_start"), ::replace_ows_targets_start);
+            case "zm_buried": //buried
+                replacefunc(getfunction("maps/mp/zm_buried_sq", "sq_metagame"), ::replace_sq_metagame);
+                if ( level.players.size < 3 ) replaceFunc(getfunction("maps/mp/zm_buried_sq_ctw", "ctw_max_wisp_enery_watch"), ::replace_ctw_max_wisp_enery_watch );
+                replacefunc(getfunction("maps/mp/zm_buried_sq_tpo", "_are_all_players_in_time_bomb_volume"), ::replace_are_all_players_in_time_bomb_volume);
+                replacefunc(getfunction("maps/mp/zm_buried_sq_ip", "sq_bp_set_current_bulb"), ::replace_sq_bp_set_current_bulb);
+                replacefunc(getfunction("maps/mp/zm_buried_sq_ows", "ows_target_delete_timer"), ::replace_ows_target_delete_timer);
+                replacefunc(getfunction("maps/mp/zm_buried_sq_ows", "ows_targets_start"), ::replace_ows_targets_start);
+                break;
+        }
 
         flag_wait("initial_players_connected");
         navcard_set();
@@ -1298,7 +1304,7 @@ replace_get_how_many_progressed_from( story, a, b )
 {
 	if ( !IS_SOLO && (isdefined( level.sq_progress[story][a] ) && !isdefined( level.sq_progress[story][b] ) || !isdefined( level.sq_progress[story][a] ) && isdefined( level.sq_progress[story][b] )) )
 		return 1;
-	else if ( IS_SOLO || isdefined( level.sq_progress[story][a] ) && isdefined( level.sq_progress[story][b] ) )
+	else if ( isdefined( level.sq_progress[story][a] ) && ( IS_SOLO || isdefined( level.sq_progress[story][b] ) ) )
 		return 2;
 
 	return 0;

--- a/timer.gsc
+++ b/timer.gsc
@@ -108,7 +108,7 @@ super_timer()
 {
     self.sort = 2000;
     self.alignx = "left";
-    self.aligny = "middle";
+    self.aligny = "top";
     self.horzalign = "user_left"; // user_left respects aspect ratio
     self.vertalign = "top";
     self.x = TIMER_X_OFFSET;
@@ -273,7 +273,7 @@ draw_client_split( index )
 {
     self.sort = 2000;
     self.alignx = "left";
-    self.aligny = "middle";
+    self.aligny = "top";
     self.horzalign = "user_left"; // user_left respects aspect ratio
     self.vertalign = "top";
     self.x = TIMER_X_OFFSET;
@@ -432,7 +432,6 @@ timer_start_wait()
     level thread game_start_check();
     if(IS_MOB) level thread mob_start_check();
     flag_wait("timer_start");
-    waittillframeend;
 }
 
 game_start_check()
@@ -1037,7 +1036,8 @@ overflow_manager()
 {
     level endon("game_ended");
 	level endon("host_migration_begin");
-    flag_wait("initial_blackscreen_passed");
+    flag_wait("initial_players_connected");
+    waittillframeend;
 
     // all strings allocated after this will be periodically removed
     level.overflow = newhudelem();
@@ -1234,7 +1234,7 @@ madeup_replaces()
         }
 
         flag_wait("initial_players_connected");
-        navcard_set();
+        if ( IS_VICTIS ) navcard_set();
         level.starting_player_count = level.players.size;
     }
 }


### PR DESCRIPTION
Added check for players number before ctw_max_wisp_enery_watch replaceFunc to ensure it does not accidentally run when more than 2p

Corrected TranZit Maxis solo behaviour for Turbines as otherwise it would make the Avogadro step on solo not need a Turbine

Only set Navcard stats on Victis maps

Avoiding the following runtime errors:
- scr_allowFileIo: Cannot set dvar in GSC
- "CENTER": type string is not a float
- "center" is not a valid value for hudelem field "aligny"
    Should be one of: top middle bottom
- level.string_count: pair 'undefined' and '1' has unmatching types 'undefined' and 'int'
    Fix used: Added waittillframeend after the flag_wait of overflow_manager and changed it to wait for "initial_players_connected"
- level.T6EE_upgrades: undefined is not an array index
- depositBox: member does not accept float types.
- in call to builtin function 'weaponclipsize'
    Weapon name "none" is not valid.
- setdstat for alt_name, dw_name: MoveToStatPath could not build stat path.
- in call to builtin function 'replacefunc'
    type undefined is not a function